### PR TITLE
Reverse relevant arrays on ngInit so lists in desired order

### DIFF
--- a/app/lucy/src/app/components/Routes/add-mechanical-treatment/add-mechanical-treatment-basic-info/add-mechanical-treatment-basic-info.component.ts
+++ b/app/lucy/src/app/components/Routes/add-mechanical-treatment/add-mechanical-treatment-basic-info/add-mechanical-treatment-basic-info.component.ts
@@ -123,7 +123,8 @@ export class AddMechanicalTreatmentBasicInfoComponent implements OnInit {
 
   ngOnInit() {
     this.dropdownService.getMechanicalTreatmentProviders().then((result) => {
-      this.mechanicalTreatmentProviders = result;
+      // reverse array so that list ordering matches order of CSV file
+      this.mechanicalTreatmentProviders = result.reverse();
     });
   }
 

--- a/app/lucy/src/app/components/Routes/add-mechanical-treatment/add-mechanical-treatment-treatment-details/add-mechanical-treatment-treatment-details.component.ts
+++ b/app/lucy/src/app/components/Routes/add-mechanical-treatment/add-mechanical-treatment-treatment-details/add-mechanical-treatment-treatment-details.component.ts
@@ -135,7 +135,8 @@ export class AddMechanicalTreatmentTreatmentDetailsComponent implements OnInit {
 
   ngOnInit() {
     this.dropdownService.getAgencies().then((result) => {
-      this.agencies = result;
+      // reverse array so that list ordering matches order of CSV file
+      this.agencies = result.reverse();
     });
 
     this.dropdownService.getMechanicalTreatmentMethods().then((result) => {

--- a/app/lucy/src/app/components/Routes/add-plant-observation/add-plant-observation-basic-information/add-plant-observation-basic-information.component.ts
+++ b/app/lucy/src/app/components/Routes/add-plant-observation/add-plant-observation-basic-information/add-plant-observation-basic-information.component.ts
@@ -146,7 +146,8 @@ export class AddPlantObservationBasicInformationComponent implements OnInit, Aft
 
   ngOnInit() {
     this.dropdownService.getAgencies().then((result) => {
-      this.agencies = result;
+      // reverse array so that list ordering matches order of CSV file
+      this.agencies = result.reverse();
     });
   }
 

--- a/app/lucy/src/app/services/dropdown.service.ts
+++ b/app/lucy/src/app/services/dropdown.service.ts
@@ -53,8 +53,6 @@ export class DropdownService {
         object: object,
       });
     }
-    // reverse array so objects are in original order
-    dropdownObjects.reverse();
     return dropdownObjects;
   }
 


### PR DESCRIPTION
Bug fix for bug fix - now only the relevant lists are being reversed