### PR TITLE
Added backend logic for admin permissions and updated readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,21 +109,32 @@ For example:
 
 `cd lucy-web`
 
+Finally, create initial local environment files:
+
+1. Create an empty `.env` file at the `api` directory root
+1. Within `api/env_config` create a `env.local` file, using `env.example` as a reference
+1. Update the app secret values in `env.local`
+
+Note: these files are git-ignored.
+
 ## Running the Application
 
 *Using Docker:*
 
-The client (frontend) and server (backend) of the application run in separate containers.
-
-To run the server, execute the following commands inside the `api` directory. To run the client, execute the following commands inside the `app` directory. Both client and server may be run independently or in parallel.
-
-The following commands are defined in the respective `Makefile` for each directory.
+The client (frontend) and server (backend) of the application run in separate containers. To run all of the application containers, execute the following commands inside the `api` directory.
 
 1. Build the application  
 `make build-local`
 
-2. Run the app container  
+2. Run the application containers  
 `make run-local`
+
+3. Run the application containers in debug mode
+`make local-debug`
+
+This will print additional logging statements to the console, which may be useful when debugging the backend.
+
+The above commands, along with additional options, are defined in the `Makefile`.
 
 *Running the App Locally:*
 
@@ -135,17 +146,13 @@ This will perform hotloading of any changes made to the frontend code (i.e., you
 
 To quit the local client, type `<Ctrl> + C`.
 
-To run the server (backend) within a Docker container, execute
-`make local-debug`
-This will print additional logging statements to the console, which may be useful when debugging the backend.
-
 *View the App:*
 
-Go to http://localhost:4200/
+Go to http://localhost:3033/
 
 *Quit the App:*
 
-On the command line, run `make close-local`
+On the command line, run `make close-local` or type `<Ctrl> + C`.
 
 ## License
 

--- a/api/README.md
+++ b/api/README.md
@@ -58,12 +58,12 @@ You can test your installation by running `node -v` and `npm -v` which should pr
 
 *Run App in Local env*
 
-* Run app: `make local`
+* Run app: `make run-local`
 * Debug app: `make local-debug`
 
 *Clean the Local App*
 
-`make clean-local`
+Note: the database has a persistant volume when run with Docker. If you need to rebuild this, run `make clean-local`
 
 ## Closing the Application
 

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -85,7 +85,6 @@ services:
     dockerfile: .build/Dockerfile.local
   ports:
     - ${APP_PORT}:${APP_PORT}
-    - 3030:3030
   volumes: 
    - ../app/lucy/src:/opt/app-root/src/src
   networks:

--- a/app/README.md
+++ b/app/README.md
@@ -9,19 +9,21 @@ To get help on Angular CLI use `ng help` or go check out the [Angular CLI README
 ## Setting Up
 ### Requirements
 
-If you wish to use the Makefile commands to run the project with Docker, there are no additional requirements required for local development.
+If you wish to use the Makefile commands to run the project with Docker from the `api` directory, there are no additional requirements required for local development.
 
 If you wish to run the application locally without Docker, you will need to install [Angular CLI](https://github.com/angular/angular-cli).
 
 ## Running the Application
 
-Run `make build-local` or `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
 
-Run `make run-local` or `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run  `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+
+Note you will also need to have the backend server running to connect to. See the [Server Readme](api/README.md) for details.
 
 ## Closing the Application
 
-Run `make close-local` or close the current process on the command line.
+To quit the local client, type `<Ctrl> + C`.
 
 ## Deployment to OpenShift
 
@@ -37,7 +39,7 @@ Run `ng build-storybook` followed by `ng storybook` to build and run tests via [
 
 ## Code Analysis with SonarQube
 
-Run `ng sonar-analysis` to see output from [SonarQube](https://www.sonarqube.org/).
+Run `npm run sonar-analysis` to see output from [SonarQube](https://www.sonarqube.org/).
 
 ## Code scaffolding
 

--- a/app/lucy/src/app/components/Routes/admin-tools/user-cell/user-cell.component.ts
+++ b/app/lucy/src/app/components/Routes/admin-tools/user-cell/user-cell.component.ts
@@ -20,8 +20,8 @@ import { User } from 'src/app/models';
 import { RolesService } from 'src/app/services/roles.service';
 import { UserService } from 'src/app/services/user.service';
 import { AdminService } from 'src/app/services/admin.service';
-import { FormsModule } from '@angular/forms';
-import { Role } from 'src/app/models/Role';
+import { Role, UserAccessType } from 'src/app/models/Role';
+import { LoadingService } from 'src/app/services/loading.service';
 import { AlertService } from 'src/app/services/alert.service';
 
 @Component({
@@ -31,7 +31,16 @@ import { AlertService } from 'src/app/services/alert.service';
 })
 export class UserCellComponent implements OnInit {
 
+  /**
+   * All currently active roles in the system
+   */
   public activeRoles: Role[] = [];
+
+  /**
+   * Current user info
+   */
+  public currentUser: User = null;
+  public currentAccessType: UserAccessType = UserAccessType.DataViewer;
 
   get username(): string {
     return this.user.preferredUsername;
@@ -65,6 +74,10 @@ export class UserCellComponent implements OnInit {
     this.setUserStatus(isActive);
   }
 
+  get canEdit(): boolean {
+    return this.canEditUser();
+  }
+
   @Input() user: User = {
     accountStatus: 0,
     createdAt: ``,
@@ -78,16 +91,46 @@ export class UserCellComponent implements OnInit {
     user_id: -1,
   }
 
-  constructor(private roles: RolesService, private userService: UserService, private admin: AdminService, private formsModule: FormsModule, private alertService: AlertService) { }
+  constructor(
+    private roles: RolesService,
+    private userService: UserService,
+    private admin: AdminService,
+    private loadingService: LoadingService,
+    private alertService: AlertService) { }
 
   ngOnInit() {
     this.getAllRoles();
+    this.getUserInfo();
   }
 
+  /**
+   * Get list of current active roles
+   */
   private getAllRoles()  {
     this.roles.getRoles().then((value) => {
       this.activeRoles = value;
     });
+  }
+
+  /**
+   * Get current user and their access type
+   */
+  private async getUserInfo() {
+    this.loadingService.add();
+    this.currentUser = await this.userService.getUser();
+    this.currentAccessType = await this.userService.getAccess();
+    this.loadingService.remove();
+  }
+
+  /**
+   * Determine if the current user can edit the target user
+   */
+  public canEditUser() {
+    if (!this.currentUser || !this.user) {
+      return false;
+    }
+    return this.currentUser.user_id != this.user.user_id &&
+      this.roles.canEditUser(this.currentAccessType, this.roles.roleToAccessType(this.userService.getUserAccessCode(this.user)))
   }
 
   public removeUser(user: User) {

--- a/app/lucy/src/app/components/base-form/base-form.component.ts
+++ b/app/lucy/src/app/components/base-form/base-form.component.ts
@@ -118,7 +118,7 @@ export class BaseFormComponent implements OnInit, AfterViewChecked {
   /**
      Message displayed after submission
   */
-  get submitedMessage(): string {
+  get submittedMessage(): string {
     if (this.creating) {
       return `Entries Added`;
     } else if (this.editing) {

--- a/app/lucy/src/app/services/roles.service.ts
+++ b/app/lucy/src/app/services/roles.service.ts
@@ -68,11 +68,24 @@ export class RolesService {
 
   public canCreate(accessType: UserAccessType) {
     return (accessType === UserAccessType.Admin ||
+      accessType === UserAccessType.SuperUser ||
       accessType === UserAccessType.DataEditor);
   }
 
   public canEdit(accessType: UserAccessType) {
     return this.canCreate(accessType);
+  }
+
+  /**
+   * Determines whether or not the current user can edit the target user.
+   * - Only admin users can edit other users at this time.
+   * - Admin users can edit all other user types at this time.
+   * 
+   * @param accessType Access type of the current user
+   * @param targetUserAccessType Access type of the user to edit
+   */
+  public canEditUser(accessType: UserAccessType, targetUserAccessType: UserAccessType) {
+    return accessType === UserAccessType.Admin;
   }
 
   private getDummyRoles(): Role[] {


### PR DESCRIPTION
This adds the logic to fix INS-722, where admin users can downgrade their own permissions. Also included is some cleanup/updates in the READMEs for how to run the app locally and with Docker.

Finally I added the super user role to some of this logic, even though it isn't currently used. This is just to make sure it doesn't jump through permissions loopholes later if we ever actually add support for it.

What's missing is the frontend changes to user-cell.component.html - when I added the simple call to toggle the button on and off using the backend logic, all of the logic worked, but the frontend styling broke. This component needs to be updated to MaterialUI to fix it. I'm going to add a patch to a new ticket for finishing these updates.

Thanks guys! :)