### PR TITLE
Ins 1045 dry storage

### DIFF
--- a/api/api_sources/schema-files/watercraftJourney.schema.yaml
+++ b/api/api_sources/schema-files/watercraftJourney.schema.yaml
@@ -37,11 +37,6 @@ schemas:
         comment: 'Details of not listed water body. This is an optional field. User can provide a brief description of water-body which is not listed in application water body list.'
         definition: VARCHAR(300) NULL 
         required: false
-      # Boolean
-      dryStorage:
-        name: dry_storage_ind
-        comment: Boolean indicator that watercraft\'s previous and/or destination waterbody is Dry Storage
-        definition: BOOLEAN NOT NULL DEFAULT FALSE
       # Relation
       watercraftAssessment:
         name: watercraft_risk_assessment_id

--- a/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
+++ b/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
@@ -96,6 +96,14 @@ schemas:
         name: high_risk_ais_ind
         comment: 'Indicator flag to check high risk AIS or not'
         definition: BOOLEAN NOT NULL DEFAULT FALSE
+      previousDryStorage:
+        name: previous_dry_storage_ind
+        comment: Boolean indicator that watercraft''s previous waterbody is Dry Storage
+        definition: BOOLEAN NOT NULL DEFAULT FALSE
+      destinationDryStorage:
+        name: destination_dry_storage_ind
+        comment: Boolean indicator that watercraft''s destination waterbody is Dry Storage
+        definition: BOOLEAN NOT NULL DEFAULT FALSE
       # Counter
       nonMotorized:
         name: 'non_motorized_counter'

--- a/api/api_sources/schema-migration-sql/WatercraftJourneySchema/WatercraftJourneySchema.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftJourneySchema/WatercraftJourneySchema.sql
@@ -6,7 +6,6 @@ ALTER TABLE watercraft_journey ADD COLUMN watercraft_journey_id SERIAL PRIMARY K
 ALTER TABLE watercraft_journey ADD COLUMN journey_type INT NOT NULL DEFAULT 0;
 ALTER TABLE watercraft_journey ADD COLUMN number_of_days_out INT NULL;
 ALTER TABLE watercraft_journey ADD COLUMN other_water_body_detail VARCHAR(300) NULL;
-ALTER TABLE watercraft_journey ADD COLUMN dry_storage_ind BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE watercraft_journey ADD COLUMN watercraft_risk_assessment_id INT NULL REFERENCES watercraft_risk_assessment(watercraft_risk_assessment_id) ON DELETE SET NULL;
 ALTER TABLE watercraft_journey ADD COLUMN water_body_id INT NULL REFERENCES water_body(water_body_id) ON DELETE SET NULL;
 
@@ -20,7 +19,6 @@ COMMENT ON COLUMN watercraft_journey.watercraft_journey_id IS 'Auto generated se
 COMMENT ON COLUMN watercraft_journey.journey_type IS 'Journey type of the associated regarding water body. i.e Previous (0) and next (1)';
 COMMENT ON COLUMN watercraft_journey.number_of_days_out IS 'Number of days out of water';
 COMMENT ON COLUMN watercraft_journey.other_water_body_detail IS 'Details of not listed water body. This is an optional field. User can provide a brief description of water-body which is not listed in application water body list.';
-COMMENT ON COLUMN watercraft_journey.dry_storage_ind IS 'Boolean indicator that watercraft''s previous and/or destination waterbody is Dry Storage';
 COMMENT ON COLUMN watercraft_journey.watercraft_risk_assessment_id IS 'Foreign key reference to Watercraft risk assessment table';
 COMMENT ON COLUMN watercraft_journey.water_body_id IS 'Foreign key reference to Water body detail table';
 

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema.sql
@@ -17,6 +17,8 @@ ALTER TABLE watercraft_risk_assessment ADD COLUMN decontamination_performed_ind 
 ALTER TABLE watercraft_risk_assessment ADD COLUMN commercially_hauled_ind BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE watercraft_risk_assessment ADD COLUMN high_risk_area_ind BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE watercraft_risk_assessment ADD COLUMN high_risk_ais_ind BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE watercraft_risk_assessment ADD COLUMN previous_dry_storage_ind BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE watercraft_risk_assessment ADD COLUMN destination_dry_storage_ind BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE watercraft_risk_assessment ADD COLUMN non_motorized_counter INT NULL;
 ALTER TABLE watercraft_risk_assessment ADD COLUMN simple_counter INT NULL;
 ALTER TABLE watercraft_risk_assessment ADD COLUMN complex_counter INT NULL;
@@ -51,6 +53,8 @@ COMMENT ON COLUMN watercraft_risk_assessment.decontamination_performed_ind IS 'S
 COMMENT ON COLUMN watercraft_risk_assessment.commercially_hauled_ind IS 'Status flag to check inspected boats are commercially hauled or not';
 COMMENT ON COLUMN watercraft_risk_assessment.high_risk_area_ind IS 'Indicator flag to check boats are from High risk area or not.';
 COMMENT ON COLUMN watercraft_risk_assessment.high_risk_ais_ind IS 'Indicator flag to check high risk AIS or not';
+COMMENT ON COLUMN watercraft_risk_assessment.previous_dry_storage_ind IS 'Boolean indicator that watercraft''s previous waterbody is Dry Storage';
+COMMENT ON COLUMN watercraft_risk_assessment.destination_dry_storage_ind IS 'Boolean indicator that watercraft''s destination waterbody is Dry Storage';
 COMMENT ON COLUMN watercraft_risk_assessment.non_motorized_counter IS 'Counter for non motorized boats in inspection';
 COMMENT ON COLUMN watercraft_risk_assessment.simple_counter IS 'Counter for number of simple boats in the inspection';
 COMMENT ON COLUMN watercraft_risk_assessment.complex_counter IS 'Counter for number of complex boats in the inspection';

--- a/api/api_sources/sources/database/models/watercraftJourney.ts
+++ b/api/api_sources/sources/database/models/watercraftJourney.ts
@@ -24,7 +24,6 @@ export interface WatercraftJourneySpec {
 	journeyType: number;
 	numberOfDaysOut: number;
 	otherWaterBody: string;
-	dryStorage: boolean;
 	watercraftAssessment: WatercraftRiskAssessment;
 	waterBody: WaterBody;
 }
@@ -39,7 +38,6 @@ export interface WatercraftJourneyUpdateSpec {
 	journeyType?: number;
 	numberOfDaysOut?: number;
 	otherWaterBody?: string;
-	dryStorage?: boolean;
 	watercraftAssessment?: WatercraftRiskAssessment;
 	waterBody?: WaterBody;
 }
@@ -87,13 +85,6 @@ export class WatercraftJourney extends Record implements WatercraftJourneySpec {
 	@Column({ name: WatercraftJourneySchema.columns.otherWaterBody})
 	@ModelProperty({type: PropertyType.string})
 	otherWaterBody: string;
-
-	/**
-	 * @description Getter/Setter property for column {dry_storage_ind}
-	 */
-	@Column({ name: WatercraftJourneySchema.columns.dryStorage})
-	@ModelProperty({type: PropertyType.boolean})
-	dryStorage: boolean;
 
 	/**
 	 * @description Getter/Setter property for column {watercraft_risk_assessment_id}

--- a/api/api_sources/sources/database/models/watercraftRiskAssessment.ts
+++ b/api/api_sources/sources/database/models/watercraftRiskAssessment.ts
@@ -65,6 +65,8 @@ export interface WatercraftRiskAssessmentSpec {
 	commerciallyHauled: boolean;
 	highRiskArea: boolean;
 	highRiskAIS: boolean;
+	previousDryStorage: boolean;
+	destinationDryStorage: boolean;
 	nonMotorized: number;
 	simple: number;
 	complex: number;
@@ -101,6 +103,8 @@ export interface WatercraftRiskAssessmentUpdateSpec {
 	commerciallyHauled?: boolean;
 	highRiskArea?: boolean;
 	highRiskAIS?: boolean;
+	previousDryStorage?: boolean;
+	destinationDryStorage?: boolean;
 	nonMotorized?: number;
 	simple?: number;
 	complex?: number;
@@ -236,6 +240,20 @@ export class WatercraftRiskAssessment extends Record implements WatercraftRiskAs
 	@Column({ name: WatercraftRiskAssessmentSchema.columns.highRiskAIS})
 	@ModelProperty({type: PropertyType.boolean})
 	highRiskAIS: boolean;
+
+	/**
+	 * @description Getter/Setter property for column {previous_dry_storage_ind}
+	 */
+	@Column({ name: WatercraftRiskAssessmentSchema.columns.previousDryStorage})
+	@ModelProperty({type: PropertyType.boolean})
+	previousDryStorage: boolean;
+
+	/**
+	 * @description Getter/Setter property for column {destination_dry_storage_ind}
+	 */
+	@Column({ name: WatercraftRiskAssessmentSchema.columns.destinationDryStorage})
+	@ModelProperty({type: PropertyType.boolean})
+	destinationDryStorage: boolean;
 
 	/**
 	 * @description Getter/Setter property for column {non_motorized_counter}


### PR DESCRIPTION
Fix required because Dry Storage should consist of 2 booleans (for previous and destination) in WatercraftRiskAssessment schema, not in WatercraftJourney schema.