### PR TITLE
L 311

### DIFF
--- a/api/api_sources/schema-files/observation.schema.yaml
+++ b/api/api_sources/schema-files/observation.schema.yaml
@@ -364,7 +364,7 @@ schemas:
         layout:
           header:
             key: 'distribution'
-            default: 'Species Distribution'
+            default: 'Observation Type'
           classes:
             - none
       speciesAgency:

--- a/api/api_sources/sources/database/models/controllers/speciesAgencyCode.controller.ts
+++ b/api/api_sources/sources/database/models/controllers/speciesAgencyCode.controller.ts
@@ -39,17 +39,6 @@ export class SpeciesAgencyCodeController extends RecordController<SpeciesAgencyC
 	public static get shared(): SpeciesAgencyCodeController {
 		return this.sharedInstance<SpeciesAgencyCode>(SpeciesAgencyCode, SpeciesAgencyCodeSchema) as SpeciesAgencyCodeController;
 	}
-
-	/**
-	 * @description Overriding all method to reverse order
-	 * @param object query
-	 * ** Sorting Code
-	 * ** (a, b) => (a.description > b.description) ? 1 : ((b.description > a.description) ? -1 : 0)
-	 */
-	async all(query?: object) {
-		const d = await super.all(query);
-		return d.reverse();
-	}
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the bug [Zenhub-311](https://app.zenhub.com/workspaces/invasivesbc-5e666c5ee0dff61a503a1917/issues/bcgov/lucy-web/311).  Note: it reorders all agency dropdown lists. This was cleared by Mike.

-Tests pass locally
- I am new to the form builder you created, and I realize that it possible to trigger database migrations by altering it so making sure it doesn't knock over the db is important.