### PR TITLE
Remove the manifest line

### DIFF
--- a/app/lucy/src/index.html
+++ b/app/lucy/src/index.html
@@ -11,7 +11,6 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#2b5797">
 


### PR DESCRIPTION
The   `<link rel="manifest" href="/site.webmanifest">` is causing some issues as this file is actually not there.
Chrome is causing an issue with our capability to log in, this issue is not experienced by Edge or FireFox.