### PR TITLE
Tweak null handling of `branch` variable.

### DIFF
--- a/api-mobile/.pipeline/config.js
+++ b/api-mobile/.pipeline/config.js
@@ -10,8 +10,8 @@ const version = config.version || '1.0.0';
 const deployType = options.type || '';
 const isStaticDeployment = deployType === 'static';
 const deployChangeId = (isStaticDeployment && 'deploy') || changeId;
-const tag = (isStaticDeployment && `build-${version}-${changeId}-${branch}`) || `build-${version}-${changeId}`;
 const branch = (isStaticDeployment && options.branch) || undefined;
+const tag = (branch && `build-${version}-${changeId}-${branch}`) || `build-${version}-${changeId}`;
 const staticUrlsAPIMobile = config.staticUrlsAPIMobile || {};
 const staticBranches = config.staticBranches || [];
 


### PR DESCRIPTION
Previous api-mobile dev build failed due to a silly variable issue, which this should hopefully address.

Screenshot of error:

![image](https://user-images.githubusercontent.com/903781/91093001-a840be00-e60d-11ea-8c01-450e0694c6dc.png)
