### PR TITLE
change timeout for cypress tests

### DIFF
--- a/app/cypress-e2e/cypress.json
+++ b/app/cypress-e2e/cypress.json
@@ -3,5 +3,6 @@
   "pluginsFile": "./cypress/plugins/index.ts",
   "screenshotsFolder": "./cypress/results/screenshots",
   "videosFolder": "./cypress/results/videos",
-  "projectId": "un3pv5"
+  "projectId": "un3pv5",
+  "pageLoadTimeout": 6000000
 }


### PR DESCRIPTION
Despite having a couple cores and 7gb of ram, the cypress tests run beyond slow and one is now timing out.  Whether we use all of what they are testing is one thing, but I"d like to keep them working as they are a good reference for what we'll likely be doing soon.  Trying to see if the pipeline works with this new timeout.