### PR TITLE
629: Add endpoint for preSigned media url

### DIFF
--- a/api-mobile/.eslintignore
+++ b/api-mobile/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 
 dist
 coverage

--- a/api-mobile/.prettierignore
+++ b/api-mobile/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 
 dist
 coverage

--- a/api-mobile/README.md
+++ b/api-mobile/README.md
@@ -66,10 +66,11 @@ The API is defined in `api-doc.yaml`.
 
 If this project is running locally, you can view the api docs at: `http://localhost:3002/api/docs/` or `http://localhost:7080/api/docs/` if running in Docker.
 
-This project uses npm package `swagger-tools` via `./app.ts` to automatically generate the express server and its routes, based on the contents of the `api-doc.yaml`.
+This project uses npm package `express-openapi` via `./app.ts` to automatically generate the express server and its routes, based on the contents of the `api-doc.yaml` and the `./src/path/` content.
 
-- The controller file is specified by the `x-swagger-router-controller` field.
-- The controller function, within the controller file, is specified by the `operationId` field.
+- The endpoint paths are defined based on the folder structure of the `./src/paths/` folder.
+  - Example: `<host>/api/activity` is handled by `./src/paths/activity.ts`
+  - Example: `<host>/api/code/observation/plant` is handled by `./src/paths/code/observation/plant.ts`
 
 Recommend reviewing the [Open API Specification](https://swagger.io/docs/specification/about/) before making any changes to the `api-doc.yaml` file.
 

--- a/api-mobile/src/openapi/api-doc.yaml
+++ b/api-mobile/src/openapi/api-doc.yaml
@@ -33,6 +33,8 @@ tags:
     description: Plant endpoints
   - name: code
     description: Code endpoints
+  - name: media
+    description: Media endpoints
 
 externalDocs:
   description: Visit GitHub to find out more about this API

--- a/api-mobile/src/paths/media/{key}.ts
+++ b/api-mobile/src/paths/media/{key}.ts
@@ -1,0 +1,66 @@
+'use strict';
+
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { ALL_ROLES } from './../../constants/misc';
+import { getS3SignedURL } from './../../utils/file-utils';
+
+export const GET: Operation = [getSignedURL()];
+
+export const parameters = [
+  {
+    in: 'path',
+    name: 'key',
+    required: true
+  }
+];
+
+GET.apiDoc = {
+  description: 'Fetches a signed url for a single media item based on its key.',
+  tags: ['media'],
+  security: [
+    {
+      Bearer: ALL_ROLES
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Activity get response object array.',
+      content: {
+        'text/plain': {
+          schema: {
+            type: 'string',
+            description: 'A signed url'
+          }
+        }
+      }
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    503: {
+      $ref: '#/components/responses/503'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+function getSignedURL(): RequestHandler {
+  return async (req, res, next) => {
+    if (!req.params.key) {
+      throw {
+        status: 400,
+        message: 'Missing required path param `key`'
+      };
+    }
+
+    const result = await getS3SignedURL(req.params.key);
+    console.log('================');
+    console.log(result);
+    console.log('================');
+
+    return res.status(200).json(result);
+  };
+}

--- a/api-mobile/src/paths/media/{key}.ts
+++ b/api-mobile/src/paths/media/{key}.ts
@@ -57,9 +57,6 @@ function getSignedURL(): RequestHandler {
     }
 
     const result = await getS3SignedURL(req.params.key);
-    console.log('================');
-    console.log(result);
-    console.log('================');
 
     return res.status(200).json(result);
   };


### PR DESCRIPTION
- new endpoint `/api/media/{key}`
  - returns a pre-signed url to fetch the object (currently expires after 5 minutes)