### PR TITLE
111: Search endpoint updates

### DIFF
--- a/api-mobile/src/constants/misc.ts
+++ b/api-mobile/src/constants/misc.ts
@@ -103,3 +103,14 @@ export enum XEnumCode {
  * @type {number}
  */
 export const SEARCH_LIMIT_MAX = 100;
+
+/**
+ * Supported PSQL `ORDER BY` directions.
+ *
+ * @export
+ * @enum {number}
+ */
+export enum SORT_DIRECTION {
+  ASC = 'ASC',
+  DESC = 'DESC'
+}

--- a/api-mobile/src/models/activity.ts
+++ b/api-mobile/src/models/activity.ts
@@ -1,4 +1,4 @@
-import { SEARCH_LIMIT_MAX } from '../constants/misc';
+import { SEARCH_LIMIT_MAX, SORT_DIRECTION } from '../constants/misc';
 import { parseBase64DataURLString } from './../utils/file-utils';
 
 /**
@@ -121,14 +121,18 @@ export class ActivityPostRequestBody {
 export class ActivitySearchCriteria {
   page: number;
   limit: number;
+  sort_by: string;
+  sort_direction: string;
 
-  activity_type: string;
-  activity_subtype: string;
+  activity_type: string[];
+  activity_subtype: string[];
 
   date_range_start: Date;
   date_range_end: Date;
 
   search_feature: GeoJSON.Feature;
+
+  column_names: string[];
 
   /**
    * Creates an instance of ActivitySearchCriteria.
@@ -139,14 +143,18 @@ export class ActivitySearchCriteria {
   constructor(obj?: any) {
     this.page = (obj && obj.page && this.setPage(obj.page)) || 0;
     this.limit = (obj && obj.limit && this.setLimit(obj.limit)) || SEARCH_LIMIT_MAX;
+    this.sort_by = (obj && obj.sort_by) || '';
+    this.sort_direction = (obj && obj.sort_direction) || SORT_DIRECTION.ASC;
 
-    this.activity_type = (obj && obj.activity_type) || null;
-    this.activity_subtype = (obj && obj.activity_subtype) || null;
+    this.activity_type = (obj && obj.activity_type) || [];
+    this.activity_subtype = (obj && obj.activity_subtype) || [];
 
     this.date_range_start = (obj && obj.date_range_start) || null;
     this.date_range_end = (obj && obj.date_range_end) || null;
 
     this.search_feature = (obj && obj.search_feature) || null;
+
+    this.column_names = (obj && obj.column_names) || [];
   }
 
   setPage(page: number): number {

--- a/api-mobile/src/openapi/api-doc.json
+++ b/api-mobile/src/openapi/api-doc.json
@@ -28,7 +28,7 @@
     },
     {
       "url": "https://api-mobile-invasivesbc.pathfinder.gov.bc.ca",
-      "description": "deployed api in prod environmen"
+      "description": "deployed api in prod environment"
     }
   ],
   "tags": [

--- a/api-mobile/src/queries/point-of-interest-queries.ts
+++ b/api-mobile/src/queries/point-of-interest-queries.ts
@@ -111,8 +111,8 @@ export const getPointsOfInterestSQL = (searchCriteria: PointOfInterestSearchCrit
     sqlStatement.append(SQL` LIMIT ${searchCriteria.limit}`);
   }
 
-  if (searchCriteria.limit) {
-    sqlStatement.append(SQL` OFFSET ${searchCriteria.page}`);
+  if (searchCriteria.page && searchCriteria.limit) {
+    sqlStatement.append(SQL` OFFSET ${searchCriteria.page * searchCriteria.limit}`);
   }
 
   sqlStatement.append(SQL`;`);


### PR DESCRIPTION
- update limit/offset logic
- support column name filtering
- support order by filter
- add count to search endpoint response
  - it now returns an object `{rows: any[], count: number}`