### PR TITLE
Tweak replica numbers to save space in openshift

### DIFF
--- a/api/.pipeline/lib/config.js
+++ b/api/.pipeline/lib/config.js
@@ -100,7 +100,7 @@ const phases = {
     certificateURL: config.certificateURL.prod,
     migrationInfo: config.migrationInfo.prod,
     replicas: 1,
-    maxReplicas: 2
+    maxReplicas: 3
   }
 };
 

--- a/api/.pipeline/lib/config.js
+++ b/api/.pipeline/lib/config.js
@@ -66,7 +66,7 @@ const phases = {
     certificateURL: config.certificateURL.dev,
     migrationInfo: config.migrationInfo.dev,
     replicas: 1,
-    maxReplicas: 2
+    maxReplicas: 1
   },
   test: {
     namespace:'7068ad-test',
@@ -82,8 +82,8 @@ const phases = {
     env: 'test',
     certificateURL: config.certificateURL.test,
     migrationInfo: config.migrationInfo.test,
-    replicas: 3,
-    maxReplicas: 5
+    replicas: 1,
+    maxReplicas: 1
   },
   prod: {
     namespace:'7068ad-prod'    , 
@@ -99,8 +99,8 @@ const phases = {
     env: 'prod',
     certificateURL: config.certificateURL.prod,
     migrationInfo: config.migrationInfo.prod,
-    replicas: 3,
-    maxReplicas: 6
+    replicas: 1,
+    maxReplicas: 2
   }
 };
 

--- a/app/.pipeline/lib/config.js
+++ b/app/.pipeline/lib/config.js
@@ -106,7 +106,7 @@ const phases = {
     env: 'prod',
     sso: sso.prod,
     replicas: 1,
-    maxReplicas: 2
+    maxReplicas: 3
   }
 };
 

--- a/app/.pipeline/lib/config.js
+++ b/app/.pipeline/lib/config.js
@@ -74,7 +74,7 @@ const phases = {
     env: 'dev',
     sso: sso.dev,
     replicas: 1,
-    maxReplicas: 3
+    maxReplicas: 1
   },
   test: {
     namespace:'7068ad-test'    , 
@@ -89,8 +89,8 @@ const phases = {
     apiHost: staticUrlsAPI['staging'] || defaultHostAPI,
     env: 'test',
     sso: sso.test,
-    replicas: 3,
-    maxReplicas: 5
+    replicas: 1,
+    maxReplicas: 1
   },
   prod: {
     namespace:'7068ad-prod'    , 
@@ -105,8 +105,8 @@ const phases = {
     apiHost: staticUrlsAPI['prod'] || defaultHostAPI,
     env: 'prod',
     sso: sso.prod,
-    replicas: 3,
-    maxReplicas: 8
+    replicas: 1,
+    maxReplicas: 2
   }
 };
 


### PR DESCRIPTION
Reduce the number of replicas (which changes how many pods are created) to save space/resources in openshift.
Before, test and prod had 3-5 pods each.
Likely 1 pod would be sufficient.