### PR TITLE
Add Major City Table Schema and JSONS

### DIFF
--- a/api/api_sources/resources/jsons/musselsApp/DaysOutOfWater.json
+++ b/api/api_sources/resources/jsons/musselsApp/DaysOutOfWater.json
@@ -1,20 +1,20 @@
 [
     {
-        "Time": "0-10 days"
+        "Days_Out_Of_Water": "0-10 days"
     },
     {
-        "Time": "11-20 days"
+        "Days_Out_Of_Water": "11-20 days"
     },
     {
-        "Time": "21-30 days"
+        "Days_Out_Of_Water": "21-30 days"
     },
     {
-        "Time": "30 days to 6 months"
+        "Days_Out_Of_Water": "30 days to 6 months"
     },
     {
-        "Time": "6 months to 1 year"
+        "Days_Out_Of_Water": "6 months to 1 year"
     },
     {
-        "Time": "> 1 year"
+        "Days_Out_Of_Water": "> 1 year"
     }
 ]

--- a/api/api_sources/resources/jsons/musselsApp/DaysOutOfWater.json
+++ b/api/api_sources/resources/jsons/musselsApp/DaysOutOfWater.json
@@ -1,0 +1,20 @@
+[
+    {
+        "Time": "0-10 days"
+    },
+    {
+        "Time": "11-20 days"
+    },
+    {
+        "Time": "21-30 days"
+    },
+    {
+        "Time": "30 days to 6 months"
+    },
+    {
+        "Time": "6 months to 1 year"
+    },
+    {
+        "Time": "> 1 year"
+    }
+]

--- a/api/api_sources/resources/jsons/musselsApp/DecontaminationOrderReasons.json
+++ b/api/api_sources/resources/jsons/musselsApp/DecontaminationOrderReasons.json
@@ -1,0 +1,17 @@
+[
+  {
+    "DecontaminationOrderReason": "Inspection/decontamination could not be performed (e.g. commercially hauled)"
+  },
+  {
+    "DecontaminationOrderReason": "Partial decontamination only"
+  },
+  {
+    "DecontaminationOrderReason": "No decontamination - pressure washer not working"
+  },
+  {
+    "DecontaminationOrderReason": "No decontamination - watercraft too complex"
+  },
+  {
+    "DecontaminationOrderReason": "INo decontamination - non-compliant refusing decontamination"
+  }
+]

--- a/api/api_sources/resources/jsons/musselsApp/DecontaminationOrderReasons.json
+++ b/api/api_sources/resources/jsons/musselsApp/DecontaminationOrderReasons.json
@@ -1,17 +1,17 @@
 [
   {
-    "DecontaminationOrderReason": "Inspection/decontamination could not be performed (e.g. commercially hauled)"
+    "Decontamination_Order_Reasons": "Inspection/decontamination could not be performed (e.g. commercially hauled)"
   },
   {
-    "DecontaminationOrderReason": "Partial decontamination only"
+    "Decontamination_Order_Reasons": "Partial decontamination only"
   },
   {
-    "DecontaminationOrderReason": "No decontamination - pressure washer not working"
+    "Decontamination_Order_Reasons": "No decontamination - pressure washer not working"
   },
   {
-    "DecontaminationOrderReason": "No decontamination - watercraft too complex"
+    "Decontamination_Order_Reasons": "No decontamination - watercraft too complex"
   },
   {
-    "DecontaminationOrderReason": "INo decontamination - non-compliant refusing decontamination"
+    "Decontamination_Order_Reasons": "No decontamination - non-compliant refusing decontamination"
   }
 ]

--- a/api/api_sources/resources/jsons/musselsApp/MusselOtherInspections.json
+++ b/api/api_sources/resources/jsons/musselsApp/MusselOtherInspections.json
@@ -19,5 +19,8 @@
   },
   {
     "Other_Inspections": "Other unidentified species"
+  },
+  {
+    "Other_Inspections": "Dirty hull or bilge"
   }
 ]

--- a/api/api_sources/schema-files/majorCities.schema.yaml
+++ b/api/api_sources/schema-files/majorCities.schema.yaml
@@ -7,11 +7,11 @@ externalTables:
     description: Country code table
   - name: country_province
     schema: CountryProvinceSchema
-    description: Country province table
+    description: Country province table 
 schemas: 
   ## -- MajorCitiesSchema
   MajorCitiesSchema:
-    name: major_cities
+    name: major_city
     description: 'The table to store all major city information. Watercraft observation require information regarding its source and destination.'
     baseSchema: RecordSchema
     meta:
@@ -30,6 +30,10 @@ schemas:
         name: 'composite'
         comment: 'Composite name of major city and country'
         definition: VARCHAR(100) NOT NULL
+      id: 
+        name: 'major_city_id'
+        comment: 'Auto generated primary key'
+        definition: SERIAL PRIMARY KEY 
       city_name:
         name: city_name
         comment: Common or popular name of the major-city
@@ -44,7 +48,7 @@ schemas:
         definition: NUMERIC(10, 7) NOT NULL
         meta: {}
       country_code:
-        name: country_code
+        name: country
         comment: Country of the city location. Joint foreign key reference to country_province table country_code column along with province_code.
         definition: VARCHAR(3) NULL
       province:

--- a/api/api_sources/schema-files/majorCities.schema.yaml
+++ b/api/api_sources/schema-files/majorCities.schema.yaml
@@ -1,0 +1,84 @@
+# Code Tables yaml
+version: '1.0'
+includes: []
+externalTables:
+  - name: country
+    schema: CountrySchema
+    description: Country code table
+  - name: country_province
+    schema: CountryProvinceSchema
+    description: Country province table
+schemas: 
+  ## -- MajorCitiesSchema
+  MajorCitiesSchema:
+    name: major_cities
+    description: 'The table to store all major city information. Watercraft observation require information regarding its source and destination.'
+    baseSchema: RecordSchema
+    meta:
+      resource: true
+      api: /mussels/major-cities
+      base: api
+    displayLayout:
+      displayLabel: '#(name)'
+      header:
+        key: MajorCitiesSchema
+        default: 'Major City'
+    layout: {}
+    computedFields: {}
+    columns: 
+      composite: 
+        name: 'composite'
+        comment: 'Composite name of major city and country'
+        definition: VARCHAR(100) NOT NULL
+      city_name:
+        name: city_name
+        comment: Common or popular name of the major-city
+        definition: VARCHAR(100) NOT NULL
+      city_longitude: 
+        name: 'city_latitude'
+        comment: 'Latitude of city location'
+        definition: NUMERIC(10, 7) NOT NULL
+      city_latitude:
+        name: 'city_longitude'
+        comment: 'Longitude of city location'
+        definition: NUMERIC(10, 7) NOT NULL
+        meta: {}
+      country_code:
+        name: country_code
+        comment: Country of the city location. Joint foreign key reference to country_province table country_code column along with province_code.
+        definition: VARCHAR(3) NULL
+      province:
+        name: province
+        comment: Province of the major_city location. Joint foreign key reference to country_province table province_code column along with country code.
+        definition: VARCHAR(2) NULL
+      location_abbreviation:
+        name: location_abbreviation
+        comment: Province of the major city location. Joint foreign key reference to country_province table province_code column along with country code.
+        definition: VARCHAR(2) NULL
+      closest_water_body:
+        name: closest_water_body
+        comment: Nearest city/landmark from the major city
+        definition: VARCHAR(100) NOT NULL
+      distance:
+        name: distance
+        comment: Distance from closest water body in kilometer
+        definition: NUMERIC(10, 5)
+  #   ## -- columns
+  #   imports:
+  #     init:
+  #       fileName: MajorCities.csv
+  #       allColumnsExcept: 
+  #         - active
+  #     ocean:
+  #       fileName: WaterBodyOcean.csv
+  #       allColumnsExcept: 
+  #         - active
+  #     june2020:
+  #       fileName: WaterBodiesJune2020.csv
+  #       allColumnsExcept: 
+  #         - active
+  # ## --    
+
+
+
+  

--- a/api/api_sources/sources/server/modules/watercraftObservation/constantData/mussels.code.route.ts
+++ b/api/api_sources/sources/server/modules/watercraftObservation/constantData/mussels.code.route.ts
@@ -15,6 +15,8 @@ const InspectorList = require('../../../../../resources/jsons/musselsApp/MusselI
 const OtherInspections = require('../../../../../resources/jsons/musselsApp/MusselOtherInspections.json');
 const Stations = require('../../../../../resources/jsons/musselsApp/MusselStationNames.json');
 const WatercraftList = require('../../../../../resources/jsons/musselsApp/MusselWatercrafts.json');
+const DecontaminationOrderReasons = require('../../../../../resources/jsons/musselsApp/DecontaminationOrderReasons.json')
+const DaysOutOfWater = require("../../../../../resources/jsons/musselsApp/DaysOutOfWater.json")
 
 /**
  * @description Route Controller for Mussel app constants
@@ -37,6 +39,8 @@ export class MusselsAppCodesRouteController extends SecureRouteController<any> {
         const otherInspection: any[] = this.processList(OtherInspections as any[], 'Other_Inspections');
         const stations: any[] = this.processList(Stations as any[], 'Station_Name');
         const watercraftList: any[] = this.processList(WatercraftList as any[], 'Watercraft');
+        const decontaminationOrderReasonList: any[] = this.processList(DecontaminationOrderReasons as any[], 'Decontamination_Order_Reasons')
+        const daysOutOfWaterList: any[] = this.processList(DaysOutOfWater as any[], "Days_Out_Of_Water")
 
         // Code tables
         const adultMusselsLocation: any[] = await AdultMusselsLocationController.shared.all();
@@ -48,6 +52,8 @@ export class MusselsAppCodesRouteController extends SecureRouteController<any> {
             otherObservations: otherInspection,
             stations: stations,
             watercraftList: watercraftList,
+            decontaminationOrderReasons: decontaminationOrderReasonList,
+            daysOutOfWater: daysOutOfWaterList,
             adultMusselsLocation,
             previousAISKnowledgeSource,
             previousInspectionSource,

--- a/api/api_sources/sources/server/modules/watercraftObservation/constantData/mussels.code.route.ts
+++ b/api/api_sources/sources/server/modules/watercraftObservation/constantData/mussels.code.route.ts
@@ -15,8 +15,8 @@ const InspectorList = require('../../../../../resources/jsons/musselsApp/MusselI
 const OtherInspections = require('../../../../../resources/jsons/musselsApp/MusselOtherInspections.json');
 const Stations = require('../../../../../resources/jsons/musselsApp/MusselStationNames.json');
 const WatercraftList = require('../../../../../resources/jsons/musselsApp/MusselWatercrafts.json');
-const DecontaminationOrderReasons = require('../../../../../resources/jsons/musselsApp/DecontaminationOrderReasons.json')
-const DaysOutOfWater = require("../../../../../resources/jsons/musselsApp/DaysOutOfWater.json")
+const DecontaminationOrderReasons = require('../../../../../resources/jsons/musselsApp/DecontaminationOrderReasons.json');
+const DaysOutOfWater = require('../../../../../resources/jsons/musselsApp/DaysOutOfWater.json');
 
 /**
  * @description Route Controller for Mussel app constants
@@ -39,8 +39,8 @@ export class MusselsAppCodesRouteController extends SecureRouteController<any> {
         const otherInspection: any[] = this.processList(OtherInspections as any[], 'Other_Inspections');
         const stations: any[] = this.processList(Stations as any[], 'Station_Name');
         const watercraftList: any[] = this.processList(WatercraftList as any[], 'Watercraft');
-        const decontaminationOrderReasonList: any[] = this.processList(DecontaminationOrderReasons as any[], 'Decontamination_Order_Reasons')
-        const daysOutOfWaterList: any[] = this.processList(DaysOutOfWater as any[], "Days_Out_Of_Water")
+        const decontaminationOrderReasonList: any[] = this.processList(DecontaminationOrderReasons as any[], 'Decontamination_Order_Reasons');
+        const daysOutOfWaterList: any[] = this.processList(DaysOutOfWater as any[], 'Days_Out_Of_Water');
 
         // Code tables
         const adultMusselsLocation: any[] = await AdultMusselsLocationController.shared.all();


### PR DESCRIPTION
Added JSONS to be sent as code tables to the front end for dropdowns. Added major cities schema and endpoint to get major cities data in mussels front end.