### PR TITLE
Add waterCraftRiskAssessment.inspection_time column

### DIFF
--- a/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
+++ b/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
@@ -255,7 +255,7 @@ schemas:
       ## -- end: numberOfPeopleInParty
       ## -- version: inspectionTime
       - name: 'inspectionTime'
-        id: '20210606'
+        id: '20210706'
         info: 'Adding new column inspectionTime'
         columns:
           inspectionTime:

--- a/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
+++ b/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
@@ -253,6 +253,18 @@ schemas:
             required: false
             meta: {}
       ## -- end: numberOfPeopleInParty
+      ## -- version: inspectionTime
+      - name: 'inspectionTime'
+        id: '20210606'
+        info: 'Adding new column inspectionTime'
+        columns:
+          inspectionTime:
+            name: inspection_time
+            comment: The time of the inspection
+            definition: VARCHAR(100) NULL
+            required: false
+            meta: {}
+      ## -- end: inspectionTime
     ## -- end version
   ## --
 

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-inspectionTime-20210706.down.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-inspectionTime-20210706.down.sql
@@ -1,0 +1,7 @@
+-- ## Reverting table: watercraft_risk_assessment
+-- ## Version: inspectionTime
+-- ## Info: Adding new column inspectionTime
+-- ## Removing New Columns ## --
+ALTER TABLE watercraft_risk_assessment DROP COLUMN IF EXISTS inspection_time;
+
+-- ## Updating watercraft_risk_assessment ## --

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-inspectionTime-20210706.up.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-inspectionTime-20210706.up.sql
@@ -1,0 +1,12 @@
+-- ## Changing table: watercraft_risk_assessment
+-- ## Version: inspectionTime
+-- ## Info: Adding new column inspectionTime
+-- ## Adding New Columns ## --
+
+-- ## Adding Column inspection_time on table watercraft_risk_assessment
+ALTER TABLE watercraft_risk_assessment ADD COLUMN inspection_time VARCHAR(100) NULL;
+COMMENT ON COLUMN watercraft_risk_assessment.inspection_time IS 'The time of the inspection';
+-- ## --
+
+
+-- ## Updating watercraft_risk_assessment ## --

--- a/api/api_sources/sources/database/migrations/1587918551000-WatercraftRiskAssessmentUpdateInspectionTime.ts
+++ b/api/api_sources/sources/database/migrations/1587918551000-WatercraftRiskAssessmentUpdateInspectionTime.ts
@@ -1,0 +1,27 @@
+import {MigrationInterface, QueryRunner} from 'typeorm';
+import { AppDBMigrator } from '../applicationSchemaInterface';
+import { WatercraftRiskAssessmentSchema } from '../database-schema';
+
+export class WatercraftRiskAssessmentUpdateInspectionTime1625599791000 extends AppDBMigrator implements MigrationInterface {
+    watercraftRiskAssessment: WatercraftRiskAssessmentSchema;
+
+    setup() {
+        this.watercraftRiskAssessment = new WatercraftRiskAssessmentSchema();
+        this.addSchemaVersion(this.watercraftRiskAssessment, 'inspectionTime');
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        // Start Log
+        this.log('[START]', 'UP');
+        // Running all up migration files
+        await this.runQuerySqlFiles(this.upMigrations(), queryRunner);
+        this.log('[END]', 'UP');
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        this.log('[STAR]', 'DOWN');
+        await this.runQuerySqlFiles(this.downMigrations(), queryRunner);
+        this.log('[END]', 'DOWN');
+    }
+
+}

--- a/api/api_sources/sources/database/models/watercraftRiskAssessment.ts
+++ b/api/api_sources/sources/database/models/watercraftRiskAssessment.ts
@@ -51,6 +51,7 @@ import { WatercraftJourney } from './watercraftJourney';
 export interface WatercraftRiskAssessmentSpec {
 	timestamp: string;
 	passportHolder: boolean;
+	inspectionTime: string;
 	isNewPassportIssued: boolean;
 	k9Inspection: boolean;
 	marineSpeciesFound: boolean;
@@ -98,6 +99,7 @@ export interface WatercraftRiskAssessmentSpec {
 export interface WatercraftRiskAssessmentUpdateSpec {
 	timestamp?: string;
 	passportHolder?: boolean;
+	inspectionTime: string;
 	k9Inspection?: boolean;
 	marineSpeciesFound?: boolean;
 	aquaticPlantsFound?: boolean;
@@ -171,6 +173,13 @@ export class WatercraftRiskAssessment extends Record implements WatercraftRiskAs
 	@Column({ name: WatercraftRiskAssessmentSchema.columns.passportHolder})
 	@ModelProperty({type: PropertyType.boolean})
 	passportHolder: boolean;
+
+	/**
+	 * @description Getter/Setter property for column {inspection_time}
+	 */
+	 @Column({ name: WatercraftRiskAssessmentSchema.columns.inspectionTime})
+	 @ModelProperty({type: PropertyType.string})
+	 inspectionTime: string;
 
 	/**
 	 * @description Getter/Setter property for column {is_new_passport_issued}

--- a/api/api_sources/sources/server/core/schema.validation.ts
+++ b/api/api_sources/sources/server/core/schema.validation.ts
@@ -156,7 +156,7 @@ export class SchemaValidator {
                     const verification = field.fieldVerification() || {};
                     if (verification.regx) {
                         const regx = new RegExp(verification.regx.re, verification.regx.flag || 'gm');
-                        assert(value.match(regx), `${printKey}: should match regx: ${regx}`);
+                        assert(regx.test(value), `${printKey}: should match regx: ${regx}`);
                     }
                 }),
                 message: 'should be string',

--- a/api/api_sources/sources/server/core/schema.validation.ts
+++ b/api/api_sources/sources/server/core/schema.validation.ts
@@ -142,10 +142,17 @@ export class SchemaValidator {
         } else {
            info = {
                 validate: validate => validate.isString().custom(async (value: string, {req}) => {
-                    // 1. Check Size
-                    assert(value, `${printKey}: Value must be defined`);
-                    assert(value.length <= typeInfo.size, `${printKey}: Exceed maximum size ${typeInfo.size}`);
-                    // 2. Regx check
+                    if (field.required) {
+                        // 1. Check Null
+                        assert(value, `${printKey}: Value must be defined`);
+                    }
+
+                    if (value) {
+                        // 2. Check Size
+                        assert(value.length <= typeInfo.size, `${printKey}: Exceed maximum size ${typeInfo.size}`);
+                    }
+
+                    // 3. Regx check
                     const verification = field.fieldVerification() || {};
                     if (verification.regx) {
                         const regx = new RegExp(verification.regx.re, verification.regx.flag || 'gm');


### PR DESCRIPTION
Includes changes from https://github.com/bcgov/lucy-web/pull/1009.
 - @sam-warren @micheal-w-wells  The only thing not included currently is the [commenting out of the string validation](https://github.com/bcgov/lucy-web/pull/1009/files#diff-7100d7d71b4d43d8eea9fbf2583bda1ae602e549bae4b6e057c68fe6da9c0b42R146-R147)
   - I wasn't sure if this change was strictly needed, or maybe just a side effect of their weird migration setup not being leveraged before? Can be added back easily of course as needed. 
 - For the migrations, I just mimicked the `numberOfPeopleInParty` column which was a field they added after the fact as a part of a migration, to see where changes were needed for the new inspection_time column.
   - This seems to be working, at least as far as the logs go.  I see the inspectionTime migration listed there along with the other migrations.
   - Edit: I see the column in schema-spy (which gets spun up as part of the pr-based deploy) so that migration does seem to be working after all.

<br>

In general, this probably just needs a quick sanity check to make sure its working as expected.

<br>

Also, regarding the failing pr-based deployment from https://github.com/bcgov/lucy-web/pull/1009
- GitHub actions can only access the secrets (needed to authenticate with Openshift, etc) if the branch being PR'd is from this repo (not from a fork).
