### PR TITLE
temp disable db deploy tools

### DIFF
--- a/api/.pipeline/deploytools.js
+++ b/api/.pipeline/deploytools.js
@@ -2,4 +2,4 @@
 const settings = require('./lib/config.js')
 const task = require('./lib/deploy.schemaspy.js')
 
-task(Object.assign(settings, { phase: settings.options.env}));
+// task(Object.assign(settings, { phase: settings.options.env}));


### PR DESCRIPTION
No longer building db, so temp removing deploy components