### PR TITLE
increase timeout to allow images to build

### DIFF
--- a/api/.pipeline/lib/wait.js
+++ b/api/.pipeline/lib/wait.js
@@ -110,5 +110,5 @@ module.exports = (resourceName, settings, countArg, timeoutArg) => {
         
     };
 
-    setTimeout(check, (timeout + 10000));
+    setTimeout(check, (timeout + 30000));
 };


### PR DESCRIPTION
Increase timeout to allow image to build in OpenShift before it's being called by GitHub Actions