### PR TITLE
console logs because local works but dev does not

### DIFF
--- a/api/api_sources/sources/AppConfig/app.config.ts
+++ b/api/api_sources/sources/AppConfig/app.config.ts
@@ -112,6 +112,7 @@ class AppConfiguration {
      */
     public get certificateURL(): string {
         assert(process.env.APP_CERTIFICATE_URL, `No App Certificate url`);
+        console.log('APP_CERTIFICATE_URL ~~~~~~~ ', process.env.APP_CERTIFICATE_URL);
         return process.env.APP_CERTIFICATE_URL;
     }
 

--- a/api/api_sources/sources/libs/utilities/bc.helpers.ts
+++ b/api/api_sources/sources/libs/utilities/bc.helpers.ts
@@ -94,6 +94,8 @@ export class BCHelperLib {
           });
         assert(certificate, 'No getJwtCertificate');
         assert(algorithm, 'No algorithm');
+        console.log(`Certificate: ~~~~~~~~ ${certificate}`);
+        console.log(`Algorithm: ~~~~~~~~ ${algorithm}`);
         return {algorithm, certificate};
     }
 

--- a/api/api_sources/sources/server/core/base.route.controller.ts
+++ b/api/api_sources/sources/server/core/base.route.controller.ts
@@ -361,6 +361,8 @@ export class RouteController {
             const tag = `authHandler-(${this.apiName(req)})`;
             try {
                 passport.authenticate('jwt', {session: false}, (err, user) => {
+                    console.log('user ~~~~~~~~ ', user);
+                    console.log('err ~~~~~~~~', err);
                     if (err) {
                         const msg = `Authorization fail with error ${err}`;
                         this.commonError(401, tag, err, resp, msg);


### PR DESCRIPTION
Console logs because the local environment shows everything working fine for the Keycloak URLs. Swapping the dev.loginproxy.gov.bc.ca links over to the loginproxy.gov.bc.ca works locally, but not on dev and for no apparent reason just yet.