### PR TITLE
[MIGRATION][LUCY-#1171] - Add a migration to add 'e.g.' to closest_city in water_body

### DIFF
--- a/api/api_sources/sources/database/migrations/1706036892274-closestCityNameChangeInWaterBody.ts
+++ b/api/api_sources/sources/database/migrations/1706036892274-closestCityNameChangeInWaterBody.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class closestCityNameChangeInWaterBody1706036892274 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`UPDATE "water_body" SET "closest_city" = CONCAT('e.g. ', "closest_city")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`UPDATE "water_body" SET "closest_city" = SUBSTRING("closest_city", 6)`);
+    }
+}


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[LUCY-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Add "e.g." to all of the `closest_city` items in the `water_body` table
