### PR TITLE
fix[LUCY-378]: Station List Update

### DIFF
--- a/api/api_sources/resources/jsons/musselsApp/MusselStationNames.json
+++ b/api/api_sources/resources/jsons/musselsApp/MusselStationNames.json
@@ -19,8 +19,6 @@
 
   { "Station_Name": "Lower Mainland Roving - Douglas" },
 
-  { "Station_Name": "Lower Mainland Roving - Huntington" },
-
   { "Station_Name": "Lower Mainland Roving - Outreach" },
 
   { "Station_Name": "Lower Mainland Roving - Scheduled Inspection" },
@@ -49,11 +47,11 @@
 
   { "Station_Name": "Cranbrook Roving - Waneta" },
 
-  { "Station_Name": "Sumas" },
+  { "Station_Name": "Sumas - Huntington" },
+
+  { "Station_Name": "Sumas/Huntington" },
 
   { "Station_Name": "Emergency Response" },
-
-  { "Station_Name": "Other" },
 
   { "Station_Name": "Project" }
 ]

--- a/api/api_sources/resources/jsons/musselsApp/MusselStationNames.json
+++ b/api/api_sources/resources/jsons/musselsApp/MusselStationNames.json
@@ -47,8 +47,6 @@
 
   { "Station_Name": "Cranbrook Roving - Waneta" },
 
-  { "Station_Name": "Sumas - Huntington" },
-
   { "Station_Name": "Sumas/Huntington" },
 
   { "Station_Name": "Emergency Response" },


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[LUCY-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Removed "Other", and "Lower mainland roving Huntington" to Station dropdown options
- Changed "Sumas" to "Sumas/Huntington"
<img width="376" height="344" alt="Screenshot 2026-01-28 at 8 55 43 AM" src="https://github.com/user-attachments/assets/b4939ba4-179b-4577-a7a7-5e425a79d1ba" />