### PR TITLE
fix[LUCY-1216/1217]: Update Drop Downs

### DIFF
--- a/api/api_sources/resources/jsons/musselsApp/DecontaminationOrderReasons.json
+++ b/api/api_sources/resources/jsons/musselsApp/DecontaminationOrderReasons.json
@@ -1,17 +1,23 @@
 [
   {
-    "Decontamination_Order_Reasons": "Inspection/decontamination could not be performed (e.g. commercially hauled)"
+    "Decontamination_Order_Reasons": "Full decontamination performed"
+  },
+  {
+    "Decontamination_Order_Reasons": "No inspection/decontamination (commercially hauled/shrink wrap)"
+  },
+  {
+    "Decontamination_Order_Reasons": "No decontamination (refusing decontamination)"
+  },
+  {
+    "Decontamination_Order_Reasons": "No decontamination (pressure washer not working)"
+  },
+  {
+    "Decontamination_Order_Reasons": "No decontamination (watercraft too complex)"
   },
   {
     "Decontamination_Order_Reasons": "Partial decontamination only"
   },
   {
-    "Decontamination_Order_Reasons": "No decontamination - pressure washer not working"
-  },
-  {
-    "Decontamination_Order_Reasons": "No decontamination - watercraft too complex"
-  },
-  {
-    "Decontamination_Order_Reasons": "No decontamination - non-compliant refusing decontamination"
+    "Decontamination_Order_Reasons": "Non compliant with pull the plug"
   }
 ]

--- a/api/api_sources/schema-migration-sql/AdultMusselsLocationSchema/AdultMusselsLocationSchema-init.sql
+++ b/api/api_sources/schema-migration-sql/AdultMusselsLocationSchema/AdultMusselsLocationSchema-init.sql
@@ -79,3 +79,8 @@ INSERT INTO adult_mussels_location_code(description)
 VALUES
 ('Bilge');
 -- ## End of item: 15 ## --
+-- ## Inserting Item: 16  ## --
+INSERT INTO adult_mussels_location_code(description)
+VALUES
+('Hull');
+-- ## End of item: 16 ## --


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[LUCY-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Updated drop down options for “Reason for issuing the Mussel Prevention Order”
- Updated drop down options for “Standing water present” location
- <img width="599" height="355" alt="Screenshot 2026-05-14 at 11 20 41 AM" src="https://github.com/user-attachments/assets/15d9c0ef-9e7e-427e-bbf3-e953b50d16f9" />
- <img width="388" height="319" alt="Screenshot 2026-05-14 at 3 23 34 PM" src="https://github.com/user-attachments/assets/5275494e-eb3b-47f6-bdfb-3fa92c00742e" />