### PR TITLE
fix[lucy-407]: Add invertedFullyDrained column to watercraftRiskAssessment table

### DIFF
--- a/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
+++ b/api/api_sources/schema-files/watercraftRiskAssessment.schema.yaml
@@ -270,18 +270,6 @@ schemas:
             required: false
             meta: {}
       ## -- end: inspectionTime
-      ## -- version: officerInspection
-      - name: "officerInspection"
-        id: "20260203"
-        info: "Adding new column officerInspection (officer_inspection_ind)"
-        columns:
-          officerInspection:
-            name: officer_inspection_ind
-            comment: "Indicator to show that inspection was directed by an officer after a blow by was returned to station"
-            definition: BOOLEAN NOT NULL DEFAULT FALSE
-            required: false
-            meta: {}
-      ## -- end: officerInspection
       ## -- version: k9InspectionResults
       - name: "k9InspectionResults"
         id: "20230330"
@@ -289,7 +277,7 @@ schemas:
         columns:
           k9InspectionResults:
             name: k9_inspection_results
-            comment: "result of k9 inspection"
+            comment: "result of the k9 inspection"
             definition: VARCHAR(100) NULL
             required: false
       ## -- end: k9InspectionResults
@@ -306,6 +294,29 @@ schemas:
           drainplugRemovedAtInspection:
             name: drainplug_removed_at_inspection
             comment: "With 'Pull The Plug' legislation in mind, were the drain plugs removed from vehicle"
+            definition: BOOLEAN NOT NULL DEFAULT FALSE
+            required: false
+      ## -- end: bilgePlugs
+      ## -- version: officerInspection
+      - name: "officerInspection"
+        id: "20260203"
+        info: "Adding new column officerInspection (officer_inspection_ind)"
+        columns:
+          officerInspection:
+            name: officer_inspection_ind
+            comment: "Indicator to show that inspection was directed by an officer after a blow by was returned to station"
+            definition: BOOLEAN NOT NULL DEFAULT FALSE
+            required: false
+            meta: {}
+      ## -- end: officerInspection
+      ## -- version: invertedFullyDrained
+      - name: "invertedFullyDrained"
+        id: "20260520"
+        info: "Adding new column invertedFullyDrained"
+        columns:
+          invertedFullyDrained:
+            name: inverted_fully_drained
+            comment: "Indicator that the inspected watercraft was transported inverted and fully drained"
             definition: BOOLEAN NOT NULL DEFAULT FALSE
             required: false
 

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-bilgePlugFields-20240605.up.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-bilgePlugFields-20240605.up.sql
@@ -11,7 +11,7 @@ COMMENT ON COLUMN watercraft_risk_assessment.watercraft_has_drainplugs IS 'Indic
 
 -- ## Adding Column drainplug_removed_at_inspection on table watercraft_risk_assessment
 ALTER TABLE watercraft_risk_assessment ADD COLUMN drainplug_removed_at_inspection BOOLEAN NOT NULL DEFAULT FALSE;
-COMMENT ON COLUMN watercraft_risk_assessment.drainplug_removed_at_inspection IS 'With "Pull The Plug" legislation in mind, were the drain plugs removed from vehicle';
+COMMENT ON COLUMN watercraft_risk_assessment.drainplug_removed_at_inspection IS 'With 'Pull The Plug' legislation in mind, were the drain plugs removed from vehicle';
 -- ## --
 
 

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-invertedFullyDrained-20260520.down.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-invertedFullyDrained-20260520.down.sql
@@ -1,0 +1,7 @@
+-- ## Reverting table: watercraft_risk_assessment
+-- ## Version: invertedFullyDrained
+-- ## Info: Adding new column invertedFullyDrained
+-- ## Removing New Columns ## --
+ALTER TABLE watercraft_risk_assessment DROP COLUMN IF EXISTS inverted_fully_drained;
+
+-- ## Updating watercraft_risk_assessment ## --

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-invertedFullyDrained-20260520.up.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-invertedFullyDrained-20260520.up.sql
@@ -1,0 +1,12 @@
+-- ## Changing table: watercraft_risk_assessment
+-- ## Version: invertedFullyDrained
+-- ## Info: Adding new column invertedFullyDrained
+-- ## Adding New Columns ## --
+
+-- ## Adding Column inverted_fully_drained on table watercraft_risk_assessment
+ALTER TABLE watercraft_risk_assessment ADD COLUMN inverted_fully_drained BOOLEAN NOT NULL DEFAULT FALSE;
+COMMENT ON COLUMN watercraft_risk_assessment.inverted_fully_drained IS 'Indicator that the inspected watercraft was transported inverted and fully drained';
+-- ## --
+
+
+-- ## Updating watercraft_risk_assessment ## --

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-k9InspectionResults-20230330.down.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-k9InspectionResults-20230330.down.sql
@@ -1,6 +1,6 @@
 -- ## Reverting table: watercraft_risk_assessment
 -- ## Version: k9InspectionResults
--- ## Info: Adding new column inspectionTime
+-- ## Info: Adding new column k9InspectionResults
 -- ## Removing New Columns ## --
 ALTER TABLE watercraft_risk_assessment DROP COLUMN IF EXISTS k9_inspection_results;
 

--- a/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-k9InspectionResults-20230330.up.sql
+++ b/api/api_sources/schema-migration-sql/WatercraftRiskAssessmentSchema/WatercraftRiskAssessmentSchema-k9InspectionResults-20230330.up.sql
@@ -1,11 +1,11 @@
 -- ## Changing table: watercraft_risk_assessment
 -- ## Version: k9InspectionResults
--- ## Info: Adding new column inspectionTime
+-- ## Info: Adding new column k9InspectionResults
 -- ## Adding New Columns ## --
 
--- ## Adding Column inspection_time on table watercraft_risk_assessment
+-- ## Adding Column k9_inspection_results on table watercraft_risk_assessment
 ALTER TABLE watercraft_risk_assessment ADD COLUMN k9_inspection_results VARCHAR(100) NULL;
-COMMENT ON COLUMN watercraft_risk_assessment.inspection_time IS 'result of the k9 inspection';
+COMMENT ON COLUMN watercraft_risk_assessment.k9_inspection_results IS 'result of the k9 inspection';
 -- ## --
 
 

--- a/api/api_sources/sources/database/migrations/1779291890244-AddInvertedFullyDrainedTo[WatercraftRiskAssessment].ts
+++ b/api/api_sources/sources/database/migrations/1779291890244-AddInvertedFullyDrainedTo[WatercraftRiskAssessment].ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { AppDBMigrator } from '../applicationSchemaInterface';
+import { WatercraftRiskAssessmentSchema } from '../database-schema';
+
+export class AddInvertedFullyDrainedTo1779291890244 extends AppDBMigrator implements MigrationInterface {
+    watercraftRiskAssessment: WatercraftRiskAssessmentSchema;
+    
+    setup() {
+        this.watercraftRiskAssessment = new WatercraftRiskAssessmentSchema();
+        this.addSchemaVersion(this.watercraftRiskAssessment, 'invertedFullyDrained');
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        // Start Log
+        this.log('[START]', 'UP');
+        // Running all up migration files
+        await this.runQuerySqlFiles(this.upMigrations(), queryRunner);
+        this.log('[END]', 'UP');
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        this.log('[STAR]', 'DOWN');
+        await this.runQuerySqlFiles(this.downMigrations(), queryRunner);
+        this.log('[END]', 'DOWN');
+    }
+
+}

--- a/api/api_sources/sources/database/models/watercraftRiskAssessment.ts
+++ b/api/api_sources/sources/database/models/watercraftRiskAssessment.ts
@@ -52,7 +52,6 @@ export interface WatercraftRiskAssessmentSpec {
 	timestamp: string;
 	passportHolder: boolean;
 	inspectionTime: string;
-    officerInspection: boolean;
 	isNewPassportIssued: boolean;
 	k9Inspection: boolean;
 	k9InspectionResults: string;
@@ -93,6 +92,8 @@ export interface WatercraftRiskAssessmentSpec {
 	numberOfPeopleInParty: number;
 	watercraftHasDrainplugs: boolean;
 	drainplugRemovedAtInspection: boolean;
+    officerInspection: boolean;
+    invertedFullyDrained: boolean;
 }
 // -- End: WatercraftRiskAssessmentSpec --
 
@@ -145,6 +146,7 @@ export interface WatercraftRiskAssessmentUpdateSpec {
 	numberOfPeopleInParty?: number;
 	watercraftHasDrainplugs: boolean;
 	drainplugRemovedAtInspection: boolean;
+	invertedFullyDrained: boolean;
 }
 // -- End: WatercraftRiskAssessmentUpdateSpec --
 
@@ -493,6 +495,13 @@ export class WatercraftRiskAssessment extends Record implements WatercraftRiskAs
 	@Column({ name: WatercraftRiskAssessmentSchema.columns.drainplugRemovedAtInspection })
 	@ModelProperty({ type: PropertyType.boolean })
 	drainplugRemovedAtInspection: boolean;
+
+    /**
+	 * @description Getter/Setter property for column {inverted_fully_drained}
+	 */
+	@Column({ name: WatercraftRiskAssessmentSchema.columns.invertedFullyDrained })
+	@ModelProperty({ type: PropertyType.boolean })
+	invertedFullyDrained: boolean;
 }
 
 // -------------------------------------


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[LUCY-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added invertedFullyDrained to watercraftRiskAssessment table
- <img width="315" height="99" alt="Screenshot 2026-05-20 at 2 07 48 PM" src="https://github.com/user-attachments/assets/067d222f-f0e8-4fc7-af62-850c2c9a1d22" />